### PR TITLE
Set environment variables with testing.Setenv

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -11,6 +11,12 @@ type env struct {
 	val string
 }
 
+func setEnvVars(t *testing.T, vars []env) {
+	for _, kv := range vars {
+		t.Setenv(kv.key, kv.val)
+	}
+}
+
 /* TODO: remove the comment below after creating tests w/ testing.Setenv
 func init() {
 	testEnvVars := []env{
@@ -40,6 +46,14 @@ func init() {
 */
 
 func Test_GetInput(t *testing.T) {
+	setEnvVars(t, []env{
+		{key: "INPUT_MY_INPUT", val: "val"},
+		{key: "INPUT_MISSING", val: ""},
+		{key: "INPUT_SPECIAL_CHARS_'\t\"\\", val: "'\t\"\\ response "},
+		{key: "INPUT_MULTIPLE_SPACES_VARIABLE", val: "I have multiple spaces"},
+		{key: "INPUT_WITH_TRAILING_WHITESPACE", val: "  some val  "},
+	})
+
 	table := []struct {
 		name     string
 		options  *InputOptions

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -1,8 +1,6 @@
 package core
 
 import (
-	"log"
-	"os"
 	"testing"
 
 	"github.com/ci-tools/toolkit/ptr"
@@ -13,6 +11,7 @@ type env struct {
 	val string
 }
 
+/* TODO: remove the comment below after creating tests w/ testing.Setenv
 func init() {
 	testEnvVars := []env{
 		{key: "INPUT_MY_INPUT", val: "val"},
@@ -38,6 +37,7 @@ func init() {
 		}
 	}
 }
+*/
 
 func Test_GetInput(t *testing.T) {
 	table := []struct {


### PR DESCRIPTION
## About

The function `testing.Setenv` is available in Go 1.17 or higher and is recommended.

- https://future-architect.github.io/articles/20210812a/
